### PR TITLE
fixed composer.json autoload casing typo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "autoload": {
         "psr-0": { 
-            "druid628\\ExactTarget\\ExactTargetBundle": "src/" 
+            "Druid628\\ExactTarget\\ExactTargetBundle": "src/"
         }
     }
 }


### PR DESCRIPTION
@druid628 there is a typo in the composer.json.
because you root namespace in ExactTargetBundle is with Uppercase "D" and on ExactTarget library lower case. For us composer autoloader won't work like this, so it would be great if you could merge this PR and create a new "stable" version tag 1.0.1 for this.

thanks in advance,
René
